### PR TITLE
Allow customizing touch-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,10 @@ Rotate action fires `rotate` event: `event.detail.rotation`. Initial rotation af
 
 ## Swipe
 
-Swipe action fires `swipe` event: `event.detail.direction`. It accepts props as parameter: `{ timeframe: number; minSwipeDistance: number }` with default values 300ms and 60px. Swipe is fired if preset distance in propper direction is done in preset time.
+Swipe action fires `swipe` event: `event.detail.direction`. It accepts props as parameter: `{ timeframe: number; minSwipeDistance: number; touchAction: string }` with default values 300ms, 60px and `none`.
+Swipe is fired if preset distance in proper direction is done in preset time.
+You can use the [touchAction](https://developer.mozilla.org/en/docs/Web/CSS/touch-action) parameter to control the default behaviour of the browser.
+For example if you only use left/right swipe and want to keep the default browser behaviour (scrolling) for up/down swipe use `touchAction: 'pan-y'`.
 
 `event.detail.direction` represents direction of swipe: 'top' | 'right' | 'bottom' | 'left'
 

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -2,6 +2,7 @@
 
 export const DEFAULT_DELAY = 300;
 export const DEFAULT_MIN_SWIPE_DISTANCE = 60; // in pixels
+export const DEFAULT_TOUCH_ACTION = 'none';
 
 type PointerType = 'up' | 'down' | 'move';
 
@@ -42,11 +43,12 @@ export function setPointerControls(
   node: HTMLElement,
   onMoveCallback: (activeEvents: PointerEvent[], event: PointerEvent) => void,
   onDownCallback: (activeEvents: PointerEvent[], event: PointerEvent) => void,
-  onUpCallback: (activeEvents: PointerEvent[], event: PointerEvent) => void
+  onUpCallback: (activeEvents: PointerEvent[], event: PointerEvent) => void,
+  touchAction: string = DEFAULT_TOUCH_ACTION
 ): {
   destroy: () => void;
 } {
-  node.style.touchAction = 'none';
+  node.style.touchAction = touchAction;
   let activeEvents: PointerEvent[] = [];
 
   function handlePointerdown(event: PointerEvent) {

--- a/src/swipe.ts
+++ b/src/swipe.ts
@@ -2,15 +2,16 @@
 
 import {
   DEFAULT_DELAY,
-  DEFAULT_MIN_SWIPE_DISTANCE,
+  DEFAULT_MIN_SWIPE_DISTANCE, DEFAULT_TOUCH_ACTION,
   setPointerControls,
 } from './shared';
 
 export function swipe(
   node: HTMLElement,
-  parameters: { timeframe: number; minSwipeDistance: number } = {
+  parameters: { timeframe: number; minSwipeDistance: number; touchAction: string } = {
     timeframe: DEFAULT_DELAY,
     minSwipeDistance: DEFAULT_MIN_SWIPE_DISTANCE,
+    touchAction: DEFAULT_TOUCH_ACTION
   }
 ): { destroy: () => void } {
   const gestureName = 'swipe';
@@ -53,5 +54,5 @@ export function swipe(
     }
   }
 
-  return setPointerControls(gestureName, node, null, onDown, onUp);
+  return setPointerControls(gestureName, node, null, onDown, onUp, parameters.touchAction);
 }


### PR DESCRIPTION
Hi,
thanks for this great lib, very easy to use.
But I think setting touch-action to `none` is not always wanted.
For example when one just wants to use left and right swipe but keep the default site scrolling on up and down swipe.

This PR adds `actionTouch` to the parameters of swipe, so it can be set to `pan-y` to keep the site scrolling active.