### PR TITLE
Allow specifying multiple values for touchAction

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Pan action (on:pan) fires `pan` event:
 The `pan` accepts the following options
 
 - `delay` (default value is 300ms)
-- `touchAction` (defaults value is `none`) Apply css _touch-action_ style, letting the browser know which type of gesture is controlled by the browser and your program respectively.
+- `touchAction` (defaults value is `none`) Apply css _touch-action_ style, to leave handling of some touch actions to the browser; see [`touch-action` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action). You can pass an array, the values will be joined with spaces.
 - `composed` is only applicable when used inside `composedGesture`.
 
 on:pan is triggered on the pointer (mouse, touch, etc.) move. But not earlier than `delay` parameter.

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -24,7 +24,7 @@ export type TouchAction =
 export type Composed = { composed: boolean };
 
 export type BaseParams = Composed & {
-  touchAction: TouchAction;
+  touchAction: TouchAction | TouchAction[];
 };
 
 type PartialParameters<GestureParams> = Partial<GestureParams>;
@@ -62,6 +62,11 @@ export type SubGestureFunctions = {
   onUp: PointerEventCallback<void>;
   onDown: PointerEventCallback<void>;
 };
+
+function ensureArray<T>(o: T | T[]): T[] {
+  if (Array.isArray(o)) return o
+  return [o]
+}
 
 function addEventListener<ET extends EventTarget, E extends Event>(
   node: ET,
@@ -123,11 +128,11 @@ export function setPointerControls(
   onMoveCallback: PointerEventCallback<boolean>,
   onDownCallback: PointerEventCallback<void>,
   onUpCallback: PointerEventCallback<void>,
-  touchAction: TouchAction = DEFAULT_TOUCH_ACTION
+  touchAction: TouchAction | TouchAction[] = DEFAULT_TOUCH_ACTION
 ): {
   destroy: () => void;
 } {
-  node.style.touchAction = touchAction;
+  node.style.touchAction = ensureArray(touchAction).join(' ');
   let activeEvents: PointerEvent[] = [];
 
   function handlePointerdown(event: PointerEvent) {


### PR DESCRIPTION
This is especially useful when you want to preserve browser behaviour for multiple touch actions. For example, I'm handling horizontal swipe to dismiss a card, but want to keep vertical swipe (aka scrolling) _and_ pinch-to-zoom (important for accessibility) working.

The syntax of the `touch-action` CSS attribute is 

```
touch-action = 
  auto                                                |
  none                                                |
  [ [ pan-x | pan-left | pan-right ] || [ pan-y | pan-up | pan-down ] || pinch-zoom ]  |
  manipulation  
```

([source](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action))

as you can see, the CSS property allows specifying multiple values. In reality, it's a bit more restrictive than that (you can't have the same value twice, you may not specify both `pan-left` and `pan-right`, etc.) but representing that within TypeScript's type system seems overly complicated. At the same time, allowing any string removes any Intellisense goodness, so I figured that allowing for arrays was the best option.

For backwards compatiblity, specifying a string still works and is equivalent to specifying a one-item array.